### PR TITLE
config path not being assigned properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var os = require('os');
 var CLOSE_TIMEOUT = 10000;
 
 if (cluster.isMaster) {
-  var configFilePath = argv.config || path.resolve('config.json');
+  var configFilePath = argv.conf || path.resolve('config.json');
   if (!fs.existsSync(configFilePath)) {
     throw new Error('Could not find a config file at path: ' + configFilePath);
   }


### PR DESCRIPTION
changed the below line : 
`var configFilePath = argv.config || path.resolve('config.json');`
to:
`var configFilePath = argv.conf || path.resolve('config.json');`

As the actual path string is stored in "conf" property, not "config". Therefore users could not load their configs from other directories. ( start --conf ./LB/config.json )